### PR TITLE
Make workflow sections three-column layout

### DIFF
--- a/css/workflow.css
+++ b/css/workflow.css
@@ -615,31 +615,37 @@
   
 /* Workflow Sections */
 .workflow-section {
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr;
+  gap: 20px;
+  align-items: start;
   padding: 60px 20px;
   background: #fff;
-  text-align: center;
 }
 .workflow-section:nth-child(odd) {
   background: var(--accent-color);
 }
-.workflow-section h2 {
+.workflow-title h2 {
   color: var(--secondary-color);
-  margin-bottom: 20px;
+  margin-top: 0;
 }
-.workflow-section img, .workflow-section embed {
-  max-width: 100%;
-  height: auto;
-  margin-bottom: 20px;
+.workflow-desc ul {
+  list-style: disc;
+  padding-left: 20px;
 }
-.workflow-section ul {
-  list-style: none;
-  padding: 0;
-}
-.workflow-section li {
-  margin: 5px 0;
-}
-.workflow-section a {
+.workflow-links a {
   color: var(--primary-color);
   text-decoration: underline;
+  display: block;
+  margin-bottom: 5px;
+}
+@media (max-width: 768px) {
+  .workflow-section {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+  .workflow-desc ul {
+    padding-left: 0;
+  }
 }
 

--- a/workflow.html
+++ b/workflow.html
@@ -42,48 +42,83 @@
     </section>
 
     <section id="analyze" class="workflow-section">
-      <h2>Analyze</h2>
-      <img src="images/strategy.gif.gif" alt="Analyze">
-      <ul>
-        <li><a href="docs/analyze_needs_analysis.pdf" target="_blank">Needs Analysis</a></li>
-      </ul>
-      <embed src="docs/analyze_needs_analysis.pdf" type="application/pdf" width="100%" height="400px">
+      <div class="workflow-title">
+        <h2>Analyze</h2>
+      </div>
+      <div class="workflow-desc">
+        <ul>
+          <li>Conduct needs assessment</li>
+          <li>Identify target audience</li>
+          <li>Define project goals</li>
+        </ul>
+      </div>
+      <div class="workflow-links">
+        <a href="docs/analyze_needs_analysis.pdf" target="_blank">Needs Analysis</a>
+      </div>
     </section>
 
     <section id="design" class="workflow-section">
-      <h2>Design</h2>
-      <img src="images/design.gif.gif" alt="Design">
-      <ul>
-        <li><a href="docs/design_storyboarding.pdf" target="_blank">Storyboarding</a></li>
-      </ul>
-      <embed src="docs/design_storyboarding.pdf" type="application/pdf" width="100%" height="400px">
+      <div class="workflow-title">
+        <h2>Design</h2>
+      </div>
+      <div class="workflow-desc">
+        <ul>
+          <li>Outline learning objectives</li>
+          <li>Plan content flow and assessments</li>
+          <li>Create storyboard documents</li>
+        </ul>
+      </div>
+      <div class="workflow-links">
+        <a href="docs/design_storyboarding.pdf" target="_blank">Storyboarding</a>
+      </div>
     </section>
 
     <section id="develop" class="workflow-section">
-      <h2>Develop</h2>
-      <img src="images/development.gif.gif" alt="Develop">
-      <ul>
-        <li><a href="docs/develop_draft.pdf" target="_blank">Development Draft</a></li>
-      </ul>
-      <embed src="docs/develop_draft.pdf" type="application/pdf" width="100%" height="400px">
+      <div class="workflow-title">
+        <h2>Develop</h2>
+      </div>
+      <div class="workflow-desc">
+        <ul>
+          <li>Build learning materials</li>
+          <li>Integrate multimedia elements</li>
+          <li>Review and revise drafts</li>
+        </ul>
+      </div>
+      <div class="workflow-links">
+        <a href="docs/develop_draft.pdf" target="_blank">Development Draft</a>
+      </div>
     </section>
 
     <section id="implement" class="workflow-section">
-      <h2>Implement</h2>
-      <img src="images/project1phone.png" alt="Implement">
-      <ul>
-        <li><a href="docs/implement_checklist.pdf" target="_blank">Implementation Checklist</a></li>
-      </ul>
-      <embed src="docs/implement_checklist.pdf" type="application/pdf" width="100%" height="400px">
+      <div class="workflow-title">
+        <h2>Implement</h2>
+      </div>
+      <div class="workflow-desc">
+        <ul>
+          <li>Launch training program</li>
+          <li>Facilitate learner access</li>
+          <li>Provide ongoing support</li>
+        </ul>
+      </div>
+      <div class="workflow-links">
+        <a href="docs/implement_checklist.pdf" target="_blank">Implementation Checklist</a>
+      </div>
     </section>
 
     <section id="evaluate" class="workflow-section">
-      <h2>Evaluate</h2>
-      <img src="images/wordcloud.png" alt="Evaluate">
-      <ul>
-        <li><a href="docs/evaluate_participant_evaluations.pdf" target="_blank">Participant Evaluations</a></li>
-      </ul>
-      <embed src="docs/evaluate_participant_evaluations.pdf" type="application/pdf" width="100%" height="400px">
+      <div class="workflow-title">
+        <h2>Evaluate</h2>
+      </div>
+      <div class="workflow-desc">
+        <ul>
+          <li>Collect learner feedback</li>
+          <li>Measure outcomes against objectives</li>
+          <li>Recommend improvements</li>
+        </ul>
+      </div>
+      <div class="workflow-links">
+        <a href="docs/evaluate_participant_evaluations.pdf" target="_blank">Participant Evaluations</a>
+      </div>
     </section>
 
   </main>


### PR DESCRIPTION
## Summary
- reformat `workflow.html` sections into a three-column grid
- add bullet points describing each ADDIE phase
- link PDFs in a dedicated column
- update `workflow.css` with responsive three-column styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68454dd0a3408326a01bba5b5297ad82