### PR TITLE
Add PDF previews to workflow page

### DIFF
--- a/css/workflow.css
+++ b/css/workflow.css
@@ -633,11 +633,21 @@
   list-style: disc;
   padding-left: 20px;
 }
+.workflow-links {
+  display: flex;
+  gap: 10px;
+}
 .workflow-links a {
-  color: var(--primary-color);
-  text-decoration: underline;
+  flex: 1;
   display: block;
-  margin-bottom: 5px;
+  text-decoration: none;
+  color: var(--primary-color);
+}
+.workflow-links embed {
+  width: 100%;
+  height: 150px;
+  border: 1px solid var(--primary-color);
+  border-radius: 4px;
 }
 @media (max-width: 768px) {
   .workflow-section {
@@ -646,6 +656,9 @@
   }
   .workflow-desc ul {
     padding-left: 0;
+  }
+  .workflow-links {
+    flex-direction: column;
   }
 }
 

--- a/workflow.html
+++ b/workflow.html
@@ -53,8 +53,12 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/Needs_Analysis_Template.pdf" target="_blank">Needs Analysis Report</a>
-        <a href="docs/Learner_Personas_Template.pdf" target="_blank">Learner Personas</a>
+        <a href="docs/Needs_Analysis_Template.pdf" target="_blank">
+          <embed src="docs/Needs_Analysis_Template.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
+        <a href="docs/Learner_Personas_Template.pdf" target="_blank">
+          <embed src="docs/Learner_Personas_Template.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
       </div>
     </section>
 
@@ -70,8 +74,12 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/Storyboard_Template.pdf" target="_blank">Storyboard</a>
-        <a href="docs/UI_Mockup_Template.pdf" target="_blank">UI Mockup</a>
+        <a href="docs/Storyboard_Template.pdf" target="_blank">
+          <embed src="docs/Storyboard_Template.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
+        <a href="docs/UI_Mockup_Template.pdf" target="_blank">
+          <embed src="docs/UI_Mockup_Template.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
       </div>
     </section>
 
@@ -87,8 +95,12 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/Module_Production_Tracker.pdf" target="_blank">Development Log</a>
-        <a href="docs/SCORM_Implementation_Plan.pdf" target="_blank">SCORM Implementation Plan</a>
+        <a href="docs/Module_Production_Tracker.pdf" target="_blank">
+          <embed src="docs/Module_Production_Tracker.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
+        <a href="docs/SCORM_Implementation_Plan.pdf" target="_blank">
+          <embed src="docs/SCORM_Implementation_Plan.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
       </div>
     </section>
 
@@ -104,8 +116,12 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/LMS_Implementation_Checklist.pdf" target="_blank">Implementation Checklist</a>
-        <a href="docs/Facilitator_Guide.pdf" target="_blank">Facilitator Guide</a>
+        <a href="docs/LMS_Implementation_Checklist.pdf" target="_blank">
+          <embed src="docs/LMS_Implementation_Checklist.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
+        <a href="docs/Facilitator_Guide.pdf" target="_blank">
+          <embed src="docs/Facilitator_Guide.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
       </div>
     </section>
 
@@ -121,8 +137,12 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/Participant_Evaluation_Summary.pdf" target="_blank">Participant Evaluations (Level 1)</a>
-        <a href="docs/Learning_Outcomes_Report.pdf" target="_blank">Learning Outcome Report (Level 2)</a>
+        <a href="docs/Participant_Evaluation_Summary.pdf" target="_blank">
+          <embed src="docs/Participant_Evaluation_Summary.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
+        <a href="docs/Learning_Outcomes_Report.pdf" target="_blank">
+          <embed src="docs/Learning_Outcomes_Report.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        </a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- display embedded PDF previews instead of text links on `workflow.html`
- style workflow links so previews sit side by side and adapt responsively

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68457436073c83269bba1a88ba0f0277