### PR TITLE
Add static PDF previews with tooltips

### DIFF
--- a/css/workflow.css
+++ b/css/workflow.css
@@ -638,16 +638,34 @@
   gap: 10px;
 }
 .workflow-links a {
+  position: relative;
   flex: 1;
   display: block;
   text-decoration: none;
   color: var(--primary-color);
+}
+.workflow-links a .pdf-tooltip {
+  display: none;
+  position: absolute;
+  top: -25px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--secondary-color);
+  color: #fff;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+.workflow-links a:hover .pdf-tooltip {
+  display: block;
 }
 .workflow-links embed {
   width: 100%;
   height: 150px;
   border: 1px solid var(--primary-color);
   border-radius: 4px;
+  pointer-events: none;
 }
 @media (max-width: 768px) {
   .workflow-section {

--- a/workflow.html
+++ b/workflow.html
@@ -53,11 +53,13 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/Needs_Analysis_Template.pdf" target="_blank">
-          <embed src="docs/Needs_Analysis_Template.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/Needs_Analysis_Template.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">Needs Analysis Template</span>
+          <embed src="docs/Needs_Analysis_Template.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
-        <a href="docs/Learner_Personas_Template.pdf" target="_blank">
-          <embed src="docs/Learner_Personas_Template.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/Learner_Personas_Template.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">Learner Personas Template</span>
+          <embed src="docs/Learner_Personas_Template.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
       </div>
     </section>
@@ -74,11 +76,13 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/Storyboard_Template.pdf" target="_blank">
-          <embed src="docs/Storyboard_Template.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/Storyboard_Template.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">Storyboard Template</span>
+          <embed src="docs/Storyboard_Template.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
-        <a href="docs/UI_Mockup_Template.pdf" target="_blank">
-          <embed src="docs/UI_Mockup_Template.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/UI_Mockup_Template.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">UI Mockup Template</span>
+          <embed src="docs/UI_Mockup_Template.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
       </div>
     </section>
@@ -95,11 +99,13 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/Module_Production_Tracker.pdf" target="_blank">
-          <embed src="docs/Module_Production_Tracker.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/Module_Production_Tracker.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">Module Production Tracker</span>
+          <embed src="docs/Module_Production_Tracker.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
-        <a href="docs/SCORM_Implementation_Plan.pdf" target="_blank">
-          <embed src="docs/SCORM_Implementation_Plan.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/SCORM_Implementation_Plan.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">SCORM Implementation Plan</span>
+          <embed src="docs/SCORM_Implementation_Plan.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
       </div>
     </section>
@@ -116,11 +122,13 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/LMS_Implementation_Checklist.pdf" target="_blank">
-          <embed src="docs/LMS_Implementation_Checklist.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/LMS_Implementation_Checklist.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">LMS Implementation Checklist</span>
+          <embed src="docs/LMS_Implementation_Checklist.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
-        <a href="docs/Facilitator_Guide.pdf" target="_blank">
-          <embed src="docs/Facilitator_Guide.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/Facilitator_Guide.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">Facilitator Guide</span>
+          <embed src="docs/Facilitator_Guide.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
       </div>
     </section>
@@ -137,11 +145,13 @@
         </ul>
       </div>
       <div class="workflow-links">
-        <a href="docs/Participant_Evaluation_Summary.pdf" target="_blank">
-          <embed src="docs/Participant_Evaluation_Summary.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/Participant_Evaluation_Summary.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">Participant Evaluation Summary</span>
+          <embed src="docs/Participant_Evaluation_Summary.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
-        <a href="docs/Learning_Outcomes_Report.pdf" target="_blank">
-          <embed src="docs/Learning_Outcomes_Report.pdf#toolbar=0" type="application/pdf" class="pdf-preview" />
+        <a href="docs/Learning_Outcomes_Report.pdf" target="_blank" class="pdf-link">
+          <span class="pdf-tooltip">Learning Outcomes Report</span>
+          <embed src="docs/Learning_Outcomes_Report.pdf#toolbar=0&page=1" type="application/pdf" class="pdf-preview" />
         </a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- preview PDFs as non-interactive first page only
- show document title tooltip on hover

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_684575d2a1c88326a13f0612c078824d